### PR TITLE
Add Xamarin.Forms Xaml pages as None Remove items to csproj

### DIFF
--- a/XamFormsSample/XamFormsSample/XamFormsSample.csproj
+++ b/XamFormsSample/XamFormsSample/XamFormsSample.csproj
@@ -11,6 +11,11 @@
   </ItemGroup>
   
   <ItemGroup>
+    <None Remove="MainPage.xaml" />
+    <None Remove="App.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="App.xaml.cs" DependentUpon="App.xaml" />
     <Compile Update="MainPage.xaml.cs" DependentUpon="MainPage.xaml" />
     <EmbeddedResource Include="MainPage.xaml" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />

--- a/XamFormsSample/XamFormsSample/XamFormsSample.csproj
+++ b/XamFormsSample/XamFormsSample/XamFormsSample.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <None Remove="MainPage.xaml" />
-    <None Remove="App.xaml" />
+    <!-- https://bugzilla.xamarin.com/show_bug.cgi?id=55591 -->
+    <None Remove="**\*.xaml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
On VS for Mac with out these lines you end up seeing the files twice in the solution explorer. See https://bugzilla.xamarin.com/show_bug.cgi?id=55591 for more details. 